### PR TITLE
Change dismissal behavior, Introduce new init on StorybookViewController

### DIFF
--- a/StorybookUI/StorybookViewController.swift
+++ b/StorybookUI/StorybookViewController.swift
@@ -34,8 +34,8 @@ public final class StorybookViewController : UISplitViewController {
         
         super.init(nibName: nil, bundle: nil)
         
-        if dismissHandler != nil {            
-            let dismissButton = UIBarButtonItem(title: "Dismiss", style: .plain, target: self, action: #selector(didTapDismissButton))
+        if dismissHandler != nil {
+            let dismissButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(didTapDismissButton))
             menuController.navigationItem.leftBarButtonItem = dismissButton
         }
         


### PR DESCRIPTION
画面の閉じ方をUIKitの基本的な方針に寄せます。
表示した側が閉じることに責任を持つ・持てるようにする。

initにdismissButtonのtapイベントを取れるclosureをセット(optional)できるようにした。
nilでなければ、dismissButtonを表示し、closureが呼び出されるようにする。

We use the concept of UIKit about dismissal modal presentation.
With this, a view controller which presented StorybookViewControler can have a responsibility to dismiss that.
