### PR TITLE
Antoine/swift6 prep

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -54,5 +54,6 @@ let package = Package(
         "StorybookKit",
       ]
     ),
-  ]
+  ],
+  swiftLanguageVersions: [.v5]
 )

--- a/Sources/StorybookKit/Primitives/Book.swift
+++ b/Sources/StorybookKit/Primitives/Book.swift
@@ -115,6 +115,7 @@ public struct FolderBuilder {
 
   public typealias Element = Book.Node
 
+  @MainActor
   public static func buildExpression<Provider: BookProvider>(_ expression: Provider.Type) -> [FolderBuilder.Element] {
     return [.page(expression.bookBody)]
   }

--- a/Sources/StorybookKit/Primitives/BookProvider.swift
+++ b/Sources/StorybookKit/Primitives/BookProvider.swift
@@ -24,6 +24,7 @@ import SwiftUI
 
 @_alwaysEmitConformanceMetadata
 public protocol BookProvider {
+  @MainActor
   static var bookBody: BookPage { get }
 }
 

--- a/Sources/StorybookKit/StorybookKit.swift
+++ b/Sources/StorybookKit/StorybookKit.swift
@@ -26,7 +26,7 @@ import Foundation
 @freestanding(declaration)
 public macro StorybookPage(
   title: String,
-  @ViewBuilder contents: @escaping () -> any View
+  @ViewBuilder contents: @escaping @MainActor () -> any View
 ) = #externalMacro(
   module: "StorybookMacrosPlugin",
   type: "StorybookPageMacro"
@@ -35,7 +35,7 @@ public macro StorybookPage(
 @freestanding(declaration)
 public macro StorybookPage<Target>(
   target: Target.Type = Target.self,
-  @ViewBuilder contents: @escaping () -> any View
+  @ViewBuilder contents: @escaping @MainActor () -> any View
 ) = #externalMacro(
   module: "StorybookMacrosPlugin",
   type: "StorybookPageMacro"
@@ -44,7 +44,7 @@ public macro StorybookPage<Target>(
 @freestanding(expression)
 public macro StorybookPreview(
   title: String,
-  @ViewBuilder contents: @escaping () -> any View
+  @ViewBuilder contents: @escaping @MainActor () -> any View
 ) -> AnyView = #externalMacro(
   module: "StorybookMacrosPlugin",
   type: "StorybookPreviewMacro"
@@ -53,7 +53,7 @@ public macro StorybookPreview(
 @freestanding(expression)
 public macro StorybookPreview<Target>(
   target: Target.Type = Target.self,
-  @ViewBuilder contents: @escaping () -> any View
+  @ViewBuilder contents: @escaping @MainActor () -> any View
 ) -> AnyView = #externalMacro(
   module: "StorybookMacrosPlugin",
   type: "StorybookPreviewMacro"

--- a/Sources/StorybookMacrosPlugin/StorybookPageMacro.swift
+++ b/Sources/StorybookMacrosPlugin/StorybookPageMacro.swift
@@ -48,6 +48,7 @@ public struct StorybookPageMacro: DeclarationMacro {
       .init(
         stringLiteral: """
         enum \(enumName): BookProvider {
+          @MainActor
           static var bookBody: BookPage {
             .init(
               title: \(title),

--- a/Sources/StorybookMacrosPlugin/StorybookPreviewMacro.swift
+++ b/Sources/StorybookMacrosPlugin/StorybookPreviewMacro.swift
@@ -48,6 +48,7 @@ public struct StorybookPreviewMacro: ExpressionMacro {
       stringLiteral: """
       {
         enum \(enumName): BookProvider {
+         @MainActor
           static var bookBody: BookPage {
             .init(
               title: \(title),

--- a/Sources/StorybookMacrosTests/StorybookPageTests.swift
+++ b/Sources/StorybookMacrosTests/StorybookPageTests.swift
@@ -47,6 +47,7 @@ final class StorybookPageTests: XCTestCase {
     } expansion: {
       """
       enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+        @MainActor
         static var bookBody: BookPage {
           .init(
             title: _typeName(UIView.self),
@@ -74,6 +75,7 @@ final class StorybookPageTests: XCTestCase {
     } expansion: {
       """
       enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+       @MainActor
         static var bookBody: BookPage {
           .init(
             title: "Path1.Path2.Title",
@@ -105,6 +107,7 @@ final class StorybookPageTests: XCTestCase {
       """
       enum Namespace1 { enum Namespace2 { enum Namespace3 { class TestableView: UIView {} } } }
       enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+        @MainActor
         static var bookBody: BookPage {
           .init(
             title: _typeName(target: Namespace1.Namespace2.Namespace3.TestableView.self),
@@ -132,6 +135,7 @@ final class StorybookPageTests: XCTestCase {
     } expansion: {
       """
       enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+        @MainActor
         static var bookBody: BookPage {
           .init(
             title: "Path1.Path2.Title",
@@ -163,6 +167,7 @@ final class StorybookPageTests: XCTestCase {
     } expansion: {
       """
       enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+        @MainActor
         static var bookBody: BookPage {
           .init(
             title: _typeName(UIView.self),
@@ -193,6 +198,7 @@ final class StorybookPageTests: XCTestCase {
     } expansion: {
       """
       enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+        @MainActor
         static var bookBody: BookPage {
           .init(
             title: "Path1.Path2.Title",
@@ -227,6 +233,7 @@ final class StorybookPageTests: XCTestCase {
       """
       enum Namespace1 { enum Namespace2 { enum Namespace3 { class TestableView: UIView {} } } }
       enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+        @MainActor
         static var bookBody: BookPage {
           .init(
             title: _typeName(
@@ -258,6 +265,7 @@ final class StorybookPageTests: XCTestCase {
     } expansion: {
       """
       enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+        @MainActor
         static var bookBody: BookPage {
           .init(
             title: "Path1.Path2.Title",

--- a/Sources/StorybookMacrosTests/StorybookPreviewTests.swift
+++ b/Sources/StorybookMacrosTests/StorybookPreviewTests.swift
@@ -51,6 +51,7 @@ final class StorybookPreviewTests: XCTestCase {
       #Preview("Some title") {
         {
           enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+            @MainActor
             static var bookBody: BookPage {
               .init(
                 title: _typeName(UIView.self),

--- a/Sources/StorybookMacrosTests/StorybookPreviewTests.swift
+++ b/Sources/StorybookMacrosTests/StorybookPreviewTests.swift
@@ -86,6 +86,7 @@ final class StorybookPreviewTests: XCTestCase {
       #Preview {
         {
           enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+            @MainActor
             static var bookBody: BookPage {
               .init(
                 title: "Path1.Path2.Title",
@@ -124,6 +125,7 @@ final class StorybookPreviewTests: XCTestCase {
       #Preview {
         {
           enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+            @MainActor
             static var bookBody: BookPage {
               .init(
                 title: _typeName(target: Namespace1.Namespace2.Namespace3.TestableView.self),
@@ -158,6 +160,7 @@ final class StorybookPreviewTests: XCTestCase {
       #Preview {
         {
           enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+            @MainActor
             static var bookBody: BookPage {
               .init(
                 title: "Path1.Path2.Title",
@@ -196,6 +199,7 @@ final class StorybookPreviewTests: XCTestCase {
       #Preview {
         {
           enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+            @MainActor
             static var bookBody: BookPage {
               .init(
                 title: _typeName(UIView.self),
@@ -233,6 +237,7 @@ final class StorybookPreviewTests: XCTestCase {
       #Preview {
         {
           enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+            @MainActor
             static var bookBody: BookPage {
               .init(
                 title: "Path1.Path2.Title",
@@ -274,6 +279,7 @@ final class StorybookPreviewTests: XCTestCase {
       #Preview {
         {
           enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+            @MainActor
             static var bookBody: BookPage {
               .init(
                 title: _typeName(
@@ -312,6 +318,7 @@ final class StorybookPreviewTests: XCTestCase {
       #Preview {
         {
           enum __macro_local_20__🤖🛠️_StorybookMagic_fMu_: BookProvider {
+            @MainActor
             static var bookBody: BookPage {
               .init(
                 title: "Path1.Path2.Title",


### PR DESCRIPTION
The macro expansion causes warnings with swift 6. This is problematic because it belongs to the client module and blocks downstream swift6 compilation