### PR TITLE
Support #Preview parsing (iOS 17+ only)

### DIFF
--- a/Development/Demo/MyBook.swift
+++ b/Development/Demo/MyBook.swift
@@ -140,6 +140,43 @@ let myBook = Book.init(
     .foregroundStyle(Color.green)
 }
 
+struct StorybookTrait: PreviewModifier {
+  func body(content: Content, context: Void) -> some View {
+    content
+  }
+}
+
+@available(iOS 18.0, *)
+extension PreviewTrait where T == Preview.ViewTraits {
+
+  @MainActor public static var storybook: PreviewTrait<Preview.ViewTraits> {
+    return .init(.modifier(StorybookTrait()))
+  }
+}
+
+struct Storybook: View {
+
+  let content: AnyView
+  init<Content: View>(
+    @ViewBuilder content: () -> Content
+  ) {
+    self.content = .init(content())
+  }
+
+  var body: some View {
+    content
+  }
+}
+
+@available(iOS 18.0, *)
+#Preview(traits: .storybook) {
+  Text("My Component")
+}
+
+#Preview {
+  Text("My Component")
+}
+
 #Preview {
   Text("NO TITLE!")
     .foregroundStyle(Color.purple)
@@ -272,18 +309,15 @@ let myBook = Book.init(
   }
 }
 
-#Preview("Some title 2") {
+#Preview("Title") {
   #StorybookPreview<MyLabel> {
     BookPreview { _ in
-      MyLabel(title: "MyLabel 2")
+      MyLabel(title: "Test")
     }
   }
 }
 
 #StorybookPage<MyLabel> {
-  BookPreview { _ in
-    MyLabel(title: "Test")
-  }
   BookPreview { _ in
     MyLabel(title: "Test")
   }

--- a/Development/Demo/MyBook.swift
+++ b/Development/Demo/MyBook.swift
@@ -135,6 +135,77 @@ let myBook = Book.init(
   }
 )
 
+#Preview("Simple Sample") {
+  Text("Yo there!")
+    .foregroundStyle(Color.green)
+}
+
+#Preview {
+  Text("NO TITLE!")
+    .foregroundStyle(Color.purple)
+}
+
+@available(iOS 17.0, *)
+#Preview("States Sample") {
+  @Previewable @State var state: Int = 1
+
+  VStack {
+    Text("Aloha \(state)")
+    Button(
+      action: { state += 1 },
+      label: { Text("+") }
+    )
+  }
+}
+
+@available(iOS 17.0, *)
+#Preview("UIView Sample") {
+  {
+    var state: Int = 1
+
+    let label = UILabel()
+    label.text = "Test \(state)"
+
+    let button = UIButton(
+      configuration: .bordered(),
+      primaryAction: .init { _ in
+        state += 1
+        label.text = "Test \(state)"
+      }
+    )
+    button.setTitle("+", for: .normal)
+    let stack = UIStackView(arrangedSubviews: [label, button])
+    stack.spacing = 8
+    return stack
+  }()
+}
+
+@available(iOS 17.0, *)
+#Preview("UIViewController Sample") {
+  {
+    let controller = UIViewController()
+    controller.view.backgroundColor = .systemMint
+    var state: Int = 1
+
+    let label = UILabel()
+    label.text = "Test \(state)"
+
+    let button = UIButton(
+      configuration: .bordered(),
+      primaryAction: .init { _ in
+        state += 1
+        label.text = "Test \(state)"
+      }
+    )
+    button.setTitle("+", for: .normal)
+    let stack = UIStackView(arrangedSubviews: [label, button])
+    stack.spacing = 8
+    stack.frame = controller.view.bounds
+    controller.view.addSubview(stack)
+    return controller
+  }()
+}
+
 #StorybookPage(title: "UILabel updating text") {
   BookPreview { context in
     let label = UILabel()

--- a/Development/Demo/RootView.swift
+++ b/Development/Demo/RootView.swift
@@ -39,8 +39,10 @@ struct RootView: View {
           }
 
           if #available(iOS 17.0, *) {
-            Book(title: "#Preview macro") {
-              Book.allBookPreviews()
+            if let nodes = Book.allBookPreviews() {
+              Book(title: "#Preview macro") {
+                nodes
+              }
             }
           }
         }

--- a/Development/Demo/RootView.swift
+++ b/Development/Demo/RootView.swift
@@ -37,6 +37,12 @@ struct RootView: View {
             Book.allStorybookPages()
               .map({ $0.bookBody })
           }
+
+          if #available(iOS 17.0, *) {
+            Book(title: "#Preview macro") {
+              Book.allBookPreviews()
+            }
+          }
         }
       )
     )

--- a/Development/Storybook.xcodeproj/project.pbxproj
+++ b/Development/Storybook.xcodeproj/project.pbxproj
@@ -324,7 +324,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -344,7 +344,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Demo/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Development/Storybook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Development/Storybook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "f5a894bbdc3287a91c8c33f864cfb447314305f7fc66cabf1c369e8c3a67521d",
   "pins" : [
     {
       "identity" : "descriptors",
@@ -32,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "15916c0c328339f54c15d616465d79700e3f7de8"
+        "revision" : "20c1a8f3b624fb5d1503eadcaa84743050c350f4",
+        "version" : "0.5.2"
       }
     },
     {
@@ -41,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "e7b77228b34057041374ebef00c0fd7739d71a2b",
-        "version" : "1.15.3"
+        "revision" : "7b0bbbae90c41f848f90ac7b4df6c4f50068256d",
+        "version" : "1.17.5"
       }
     },
     {
@@ -50,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     },
     {
@@ -86,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidGroup/TextureBridging.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "4383f8a9846a0507d2c22ee9fac22153f9b86fed"
+        "revision" : "4383f8a9846a0507d2c22ee9fac22153f9b86fed",
+        "version" : "3.2.1"
       }
     },
     {
@@ -95,10 +96,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidGroup/TextureSwiftSupport.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "5bae50cab3798dccb8b98c3ffbc70320ae66b45a"
+        "revision" : "fb748d6a9d0a2dca0635227e1db0360fd26e0e24",
+        "version" : "3.20.1"
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Sources/StorybookKit/Internals/Preview/PreviewRegistryWrapper.swift
+++ b/Sources/StorybookKit/Internals/Preview/PreviewRegistryWrapper.swift
@@ -1,0 +1,203 @@
+import DeveloperToolsSupport
+import Foundation
+import SwiftUI
+import UIKit
+
+@available(iOS 17.0, *)
+struct PreviewRegistryWrapper: Comparable {
+
+  let previewType: any DeveloperToolsSupport.PreviewRegistry.Type
+  let module: String
+
+  init(_ previewType: any DeveloperToolsSupport.PreviewRegistry.Type) {
+    self.previewType = previewType
+    self.module = previewType.fileID.components(separatedBy: "/").first!
+  }
+
+  var fileID: String { previewType.fileID }
+  var line: Int { previewType.line }
+  var column: Int { previewType.column }
+
+  @MainActor
+  var makeView: (@MainActor () -> any View) {
+    let preview: FieldReader = .init(try! previewType.makePreview())
+    let title: String? = preview["displayName"]
+    let source: FieldReader = preview["source"]
+    switch source.typeName {
+
+    case "SwiftUI.ViewPreviewSource": // iOS 17
+      let makeView: MakeFunctionWrapper<any SwiftUI.View> = .init(source["makeView"])
+      return {
+        VStack {
+          if let title, !title.isEmpty {
+            Text(title)
+              .font(.system(size: 17, weight: .semibold))
+          }
+          AnyView(makeView())
+          Text("\(fileID):\(line)")
+            .font(.caption.monospacedDigit())
+          BookSpacer(height: 16)
+        }
+      }
+
+    case "UIKit.UIViewPreviewSource": // iOS 17
+      // Unsupported due to iOS 17 not supporting casting between non-sendable closure types
+      return {
+        VStack {
+          if let title, !title.isEmpty {
+            Text(title)
+              .font(.system(size: 17, weight: .semibold))
+          }
+          Text("\(fileID):\(line)")
+            .font(.caption.monospacedDigit())
+          Text("UIView Preview not supported (UIKit.UIViewPreviewSource)")
+            .foregroundStyle(Color.red)
+            .font(.caption.monospacedDigit())
+          BookSpacer(height: 16)
+        }
+      }
+
+    case "DeveloperToolsSupport.DefaultPreviewSource<SwiftUI.ViewPreviewBody>": // iOS 18
+      let makeBody: MakeFunctionWrapper<any SwiftUI.View> = .init(source["structure", "singlePreview", "makeBody"])
+      return {
+        VStack {
+          if let title, !title.isEmpty {
+            Text(title)
+              .font(.system(size: 17, weight: .semibold))
+          }
+          AnyView(makeBody())
+          Text("\(fileID):\(line)")
+            .font(.caption.monospacedDigit())
+          BookSpacer(height: 16)
+        }
+      }
+
+    case "DeveloperToolsSupport.DefaultPreviewSource<__C.UIView>": // iOS 18
+      let makeBody: MakeFunctionWrapper<UIView> = .init(source["structure", "singlePreview", "makeBody"])
+      return {
+        BookPreview(
+          fileID,
+          line,
+          title: title ?? source.typeName,
+          viewBlock: { _ in
+            makeBody()
+          }
+        )
+      }
+
+    case "DeveloperToolsSupport.DefaultPreviewSource<__C.UIViewController>": // iOS 18
+      let makeBody: MakeFunctionWrapper<UIViewController> = .init(source["structure", "singlePreview", "makeBody"])
+      return {
+        BookPresent(
+          title: title ?? source.typeName,
+          presentingViewControllerBlock: {
+            makeBody()
+          }
+        )
+      }
+
+    case let sourceTypeName:
+      return {
+        VStack {
+          if let title, !title.isEmpty {
+            Text(title)
+              .font(.system(size: 17, weight: .semibold))
+          }
+          Text("\(fileID):\(line)")
+            .font(.caption.monospacedDigit())
+          Text("Failed to load preview (\(sourceTypeName))")
+            .foregroundStyle(Color.red)
+            .font(.caption.monospacedDigit())
+          BookSpacer(height: 16)
+        }
+      }
+    }
+  }
+
+
+  // MARK: Comparable
+
+  static func < (lhs: PreviewRegistryWrapper, rhs: PreviewRegistryWrapper) -> Bool {
+    if lhs.module == rhs.module {
+      return lhs.line < rhs.line
+    }
+    return lhs.module < rhs.module
+  }
+
+
+  // MARK: Equatable
+
+  static func == (lhs: PreviewRegistryWrapper, rhs: PreviewRegistryWrapper) -> Bool {
+    lhs.line == rhs.line && lhs.module == rhs.module
+  }
+
+
+  // MARK: - FieldReader
+
+  private struct FieldReader {
+
+    let instance: Any
+    let typeName: String
+
+    init(_ instance: Any) {
+      self.instance = instance
+      self.typeName = String(reflecting: type(of: instance))
+      let mirror: Mirror = .init(reflecting: instance)
+      self.fields = .init(
+        uniqueKeysWithValues: mirror.children.compactMap { (label, value) in
+          label.map({ ($0, value) })
+        }
+      )
+    }
+
+    subscript<T>(_ key: String, _ nextKeys: String...) -> T {
+      if nextKeys.isEmpty {
+        return fields[key] as! T
+      }
+      else {
+        return Self.traverse(from: fields[key]!, nextKeys: nextKeys) as! T
+      }
+    }
+
+    subscript(_ key: String, _ nextKeys: String...) -> FieldReader {
+      .init(Self.traverse(from: fields[key]!, nextKeys: nextKeys))
+    }
+
+    private let fields: [String: Any]
+
+    private static func traverse<C: Collection<String>>(from first: Any, nextKeys: C) -> Any {
+      if let key = nextKeys.first {
+        let mirror: Mirror = .init(reflecting: first)
+        return self.traverse(
+          from: mirror.children.first(where: { $0.label == key })!.value,
+          nextKeys: nextKeys.dropFirst()
+        )
+      }
+      else {
+        return first
+      }
+    }
+  }
+
+
+  // MARK: - MakeFunctionWrapper
+
+  @MainActor
+  private struct MakeFunctionWrapper<T> {
+
+    typealias Closure = @MainActor () -> T
+    private let closure: Closure
+
+    init(_ closure: Any) {
+      // TODO: We need a workaround to avoid implicit @Sendable from @MainActor closures
+      self.closure = unsafeBitCast(
+        closure,
+        to: Closure.self
+      )
+    }
+
+    func callAsFunction() -> T {
+      closure()
+    }
+  }
+}

--- a/Sources/StorybookKit/Internals/machOLoader.swift
+++ b/Sources/StorybookKit/Internals/machOLoader.swift
@@ -180,7 +180,8 @@ extension Book {
         continue
       }
       guard
-        contextDescriptor.pointee.kind().canConformToProtocol,
+        case .structType = contextDescriptor.pointee.kind(),
+        contextDescriptor.nameContains("PreviewRegistry"),
         !excludeStorybookPageMacro || !contextDescriptor.nameContains(self._magicSubstring)
       else {
         continue
@@ -358,7 +359,7 @@ fileprivate struct SwiftTypeContextDescriptor: SwiftLayoutPointer {
     }
 
     var canConformToProtocol: Bool {
-      return (Self.classType.rawValue ... Self.typesEnd.rawValue).contains(self.rawValue)
+      return (Self.typesStart.rawValue ... Self.typesEnd.rawValue).contains(self.rawValue)
     }
   }
 }

--- a/Sources/StorybookKit/Internals/machOLoader.swift
+++ b/Sources/StorybookKit/Internals/machOLoader.swift
@@ -113,6 +113,38 @@ extension Book {
         metadataAccessFunction,
         to: Any.Type.self
       )
+      if #available(iOS 17.0, *) {
+        if let previewType = anyType as? any DeveloperToolsSupport.PreviewRegistry.Type {
+          print("========")
+          print("fileID: \(previewType.fileID)")
+          print("line: \(previewType.line)")
+          print("column: \(previewType.column)")
+          
+          let preview = try! previewType.makePreview()
+          dump(preview)
+
+          let mirror: Mirror = .init(reflecting: preview)
+          for child in mirror.children {
+            switch child.label {
+            case "displayName":
+              print("displayName: \(child.value)")
+
+            case "source":
+              let mirror: Mirror = .init(reflecting: child.value)
+              let factory = mirror.children.first!.value as! @MainActor () -> any SwiftUI.View
+//              let view = AnyView(factory())
+              print("view:")
+              let anyView: AnyView = MainActor.assumeIsolated(factory) as! AnyView
+              dump(anyView)
+              print("========")
+
+            default:
+              break
+            }
+          }
+          print("========")
+        }
+      }
       guard let bookProviderType = anyType as? any BookProvider.Type else {
         continue
       }

--- a/Sources/StorybookKit/Internals/machOLoader.swift
+++ b/Sources/StorybookKit/Internals/machOLoader.swift
@@ -112,12 +112,7 @@ extension Book {
       }
       guard
         contextDescriptor.pointee.kind().canConformToProtocol,
-        !filterByStorybookPageMacro || self._magicSubstring.withCString(
-          {
-            let nameCString = contextDescriptor.resolvePointer(for: \.name)
-            return nil != strstr(nameCString, $0)
-          }
-        )
+        !filterByStorybookPageMacro || contextDescriptor.nameContains(self._magicSubstring)
       else {
         continue
       }
@@ -187,12 +182,7 @@ extension Book {
       }
       guard
         contextDescriptor.pointee.kind().canConformToProtocol,
-        !excludeStorybookPageMacro || !self._magicSubstring.withCString(
-          {
-            let nameCString = contextDescriptor.resolvePointer(for: \.name)
-            return nil != strstr(nameCString, $0)
-          }
-        )
+        !excludeStorybookPageMacro || !contextDescriptor.nameContains(self._magicSubstring)
       else {
         continue
       }
@@ -231,7 +221,7 @@ extension Book {
         let fileID = previewType.fileID
         let line = previewType.line
         let preview = try! previewType.makePreview()
-
+//        dump(preview)
         var title: String?
         var makeBookView: ((String) -> any View)?
         let previewMirror: Mirror = .init(reflecting: preview)
@@ -277,8 +267,16 @@ extension Book {
 //              let factory = MakeViewFactory<UIKit.UIView>(anyFactory.value)
 //              let view = factory()
 //              print(view)
-//              dump(view)
-//              anyView = .init(view)
+//              makeBookView = { title in
+//                BookPreview(
+//                  fileID,
+//                  line,
+//                  title: title,
+//                  viewBlock: { _ in
+//                    view
+//                  }
+//                )
+//              }
 
             case "DeveloperToolsSupport.DefaultPreviewSource<SwiftUI.ViewPreviewBody>": // iOS 18
               guard
@@ -356,17 +354,17 @@ extension Book {
               }
 
             case let sourceTypeName:
-              print(sourceTypeName)
+//              print(sourceTypeName)
               break
             }
 
           case "traits":
-            let traitsMirror: Mirror = .init(reflecting: previewChild.value)
-            dump(traitsMirror)
+//            let traitsMirror: Mirror = .init(reflecting: previewChild.value)
+//            dump(traitsMirror)
             break
 
           default:
-            print(previewChild.label)
+//            print(previewChild.label)
             break
           }
         }
@@ -426,7 +424,7 @@ extension Book {
 
 extension UnsafePointer where Pointee: SwiftLayoutPointer {
 
-  func resolvePointer<U>(for keyPath: KeyPath<Pointee, SwiftRelativePointer<U>>) -> UnsafePointer<U> {
+  fileprivate func resolvePointer<U>(for keyPath: KeyPath<Pointee, SwiftRelativePointer<U>>) -> UnsafePointer<U> {
     let base: UnsafeRawPointer = .init(self)
     let fieldOffset = MemoryLayout<Pointee>.offset(of: keyPath)!
     let relativePointer = self.pointee[keyPath: keyPath]
@@ -436,7 +434,7 @@ extension UnsafePointer where Pointee: SwiftLayoutPointer {
       .assumingMemoryBound(to: U.self)
   }
 
-  func resolveValue<U>(for keyPath: KeyPath<Pointee, SwiftRelativePointer<U>>) -> U {
+  fileprivate func resolveValue<U>(for keyPath: KeyPath<Pointee, SwiftRelativePointer<U>>) -> U {
     let base: UnsafeRawPointer = .init(self)
     let fieldOffset = MemoryLayout<Pointee>.offset(of: keyPath)!
     let relativePointer = self.pointee[keyPath: keyPath]
@@ -447,17 +445,28 @@ extension UnsafePointer where Pointee: SwiftLayoutPointer {
   }
 }
 
-protocol SwiftLayoutPointer {
+extension UnsafePointer where Pointee == SwiftTypeContextDescriptor {
+  fileprivate func nameContains(_ string: String) -> Bool {
+    string.withCString(
+      {
+        let nameCString = self.resolvePointer(for: \.name)
+        return nil != strstr(nameCString, $0)
+      }
+    )
+  }
+}
+
+fileprivate protocol SwiftLayoutPointer {
   static var maskValue: Int32 { get }
 }
 
 extension SwiftLayoutPointer {
-  static var maskValue: Int32 {
+  fileprivate static var maskValue: Int32 {
     return 0
   }
 }
 
-struct SwiftRelativePointer<T> {
+fileprivate struct SwiftRelativePointer<T> {
 
   var offset: Int32 = 0
 
@@ -495,7 +504,7 @@ extension SwiftRelativePointer where T: SwiftLayoutPointer {
   }
 }
 
-struct SwiftTypeMetadataRecord: SwiftLayoutPointer {
+fileprivate struct SwiftTypeMetadataRecord: SwiftLayoutPointer {
 
   var pointer: SwiftRelativePointer<SwiftTypeContextDescriptor>
 
@@ -521,7 +530,7 @@ struct SwiftTypeMetadataRecord: SwiftLayoutPointer {
   }
 }
 
-struct SwiftTypeContextDescriptor: SwiftLayoutPointer {
+fileprivate struct SwiftTypeContextDescriptor: SwiftLayoutPointer {
   var flags: UInt32 = 0
   var parent: SwiftRelativePointer<UInt8> = .init()
   var name: SwiftRelativePointer<CChar> = .init()

--- a/Sources/StorybookKit/Primitives/Book.swift
+++ b/Sources/StorybookKit/Primitives/Book.swift
@@ -51,26 +51,31 @@ public struct Book: BookView, Identifiable {
                   0,
                   title: .init(fileID[module.endIndex...]),
                   destination: { [registries = registriesByFileID[fileID]!] in
-                    ScrollView {
-                      LazyVStack(
-                        alignment: .center,
-                        spacing: 16,
-                        pinnedViews: .sectionHeaders
-                      ) {
-                        Section(
-                          content: {
-                            ForEach.inefficient(items: registries) { registry in
-                              AnyView(registry.makeView())
-                            }
-                          },
-                          header: {
-                            Text(fileID)
-                              .truncationMode(.head)
-                              .font(.caption.monospacedDigit())
+                    LazyVStack(
+                      alignment: .center,
+                      spacing: 16,
+                      pinnedViews: .sectionHeaders
+                    ) {
+                      Section(
+                        content: {
+                          ForEach.inefficient(items: registries) { registry in
+                            AnyView(registry.makeView())
                           }
-                        )
-                      }
+                        },
+                        header: {
+                          Text(fileID)
+                            .multilineTextAlignment(.leading)
+                            .truncationMode(.head)
+                            .foregroundStyle(.secondary)
+                            .font(.caption.monospacedDigit())
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 8)
+                            .frame(maxWidth: .infinity)
+                            .background(.thickMaterial)
+                        }
+                      )
                     }
+                    .edgesIgnoringSafeArea(.top)
                   }
                 )
               )

--- a/Sources/StorybookKit/Primitives/Book.swift
+++ b/Sources/StorybookKit/Primitives/Book.swift
@@ -27,6 +27,12 @@ public struct Book: BookView, Identifiable {
   public let title: String
   public let contents: [Node]
 
+  /// All `#Preview`s as `BookPage`s
+  @available(iOS 17.0, *)
+  public static func allBookPreviews() -> [BookPage] {
+    self.findAllPreviews() ?? []
+  }
+
   /// All conformers to `BookProvider`, including those declared from the `#StorybookPage` macro
   public static func allBookProviders() -> [any BookProvider.Type] {
     self.findAllBookProviders(filterByStorybookPageMacro: false) ?? []

--- a/Sources/StorybookKit/Primitives/Book.swift
+++ b/Sources/StorybookKit/Primitives/Book.swift
@@ -49,33 +49,17 @@ public struct Book: BookView, Identifiable {
                 .init(
                   fileID,
                   0,
-                  title: .init(fileID[module.endIndex...]),
+                  title: .init(fileID[fileID.index(after: module.endIndex)...]),
                   destination: { [registries = registriesByFileID[fileID]!] in
                     LazyVStack(
                       alignment: .center,
                       spacing: 16,
                       pinnedViews: .sectionHeaders
                     ) {
-                      Section(
-                        content: {
-                          ForEach.inefficient(items: registries) { registry in
-                            AnyView(registry.makeView())
-                          }
-                        },
-                        header: {
-                          Text(fileID)
-                            .multilineTextAlignment(.leading)
-                            .truncationMode(.head)
-                            .foregroundStyle(.secondary)
-                            .font(.caption.monospacedDigit())
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 8)
-                            .frame(maxWidth: .infinity)
-                            .background(.thickMaterial)
-                        }
-                      )
+                      ForEach.inefficient(items: registries) { registry in
+                        AnyView(registry.makeView())
+                      }
                     }
-                    .edgesIgnoringSafeArea(.top)
                   }
                 )
               )
@@ -144,6 +128,7 @@ public struct Book: BookView, Identifiable {
             folder
           }
           .navigationTitle(folder.title)
+          .navigationBarTitleDisplayMode(.inline)
         } label: {
           HStack {
             Image.init(systemName: "folder")

--- a/Sources/StorybookKit/Primitives/BookPage.swift
+++ b/Sources/StorybookKit/Primitives/BookPage.swift
@@ -82,6 +82,8 @@ public struct BookPage: BookView, Identifiable {
         destination
       }
       .listStyle(.plain)
+      .navigationTitle(title)
+      .navigationBarTitleDisplayMode(.inline)
       .onAppear(perform: {
         context?.onOpen(pageID: id)
       })

--- a/Sources/StorybookKit/Primitives/BookPage.swift
+++ b/Sources/StorybookKit/Primitives/BookPage.swift
@@ -59,12 +59,12 @@ public struct BookPage: BookView, Identifiable {
   public let title: String
   public let destination: AnyView
   public nonisolated let declarationIdentifier: DeclarationIdentifier
-  private let file: StaticString
-  private let line: UInt
+  private let file: String
+  private let line: Int
 
   public init<Destination: View>(
-    _ file: StaticString = #fileID,
-    _ line: UInt = #line,
+    _ file: String = #fileID,
+    _ line: Int = #line,
     title: String,
     @ViewBuilder destination: @MainActor () -> Destination
   ) {

--- a/Sources/StorybookKit/Primitives/BookPage.swift
+++ b/Sources/StorybookKit/Primitives/BookPage.swift
@@ -59,16 +59,16 @@ public struct BookPage: BookView, Identifiable {
   public let title: String
   public let destination: AnyView
   public nonisolated let declarationIdentifier: DeclarationIdentifier
-  private let file: String
-  private let line: Int
+  private let fileID: any StringProtocol
+  private let line: any FixedWidthInteger
 
   public init<Destination: View>(
-    _ file: String = #fileID,
-    _ line: Int = #line,
+    _ fileID: any StringProtocol = #fileID,
+    _ line: any FixedWidthInteger = #line,
     title: String,
     @ViewBuilder destination: @MainActor () -> Destination
   ) {
-    self.file = file
+    self.fileID = fileID
     self.line = line
     self.title = title
     self.destination = AnyView(destination())
@@ -83,14 +83,14 @@ public struct BookPage: BookView, Identifiable {
       }
       .listStyle(.plain)
       .onAppear(perform: {
-        context?.onOpen(page: self)
+        context?.onOpen(pageID: id)
       })
     } label: {
       HStack {
         Image.init(systemName: "doc")
         VStack(alignment: .leading) {
           Text(title)
-          Text("\(file.description):\(line.description)")
+          Text("\(fileID):\(line)")
             .font(.caption.monospacedDigit())
             .opacity(0.8)
         }

--- a/Sources/StorybookKit/Primitives/BookPreview.swift
+++ b/Sources/StorybookKit/Primitives/BookPreview.swift
@@ -46,20 +46,20 @@ public struct BookPreview: BookView {
 
   public let declarationIdentifier: DeclarationIdentifier
 
-  private let file: String
-  private let line: Int
+  private let fileID: any StringProtocol
+  private let line: any FixedWidthInteger
   private let title: String?
   private var frameConstraint: FrameConstraint = .init()
 
   public init(
-    _ file: String = #fileID,
-    _ line: Int = #line,
+    _ fileID: any StringProtocol = #fileID,
+    _ line: any FixedWidthInteger = #line,
     title: String? = nil,
     viewBlock: @escaping @MainActor (inout Context) -> UIView
   ) {
 
     self.title = title
-    self.file = file
+    self.fileID = fileID
     self.line = line
     self.viewBlock = viewBlock
 
@@ -95,7 +95,7 @@ public struct BookPreview: BookView {
 
       controlView
 
-      Text("\(file.description):\(line.description)")
+      Text("\(fileID):\(line)")
         .font(.caption.monospacedDigit())
 
       BookSpacer(height: 16)

--- a/Sources/StorybookKit/Primitives/BookPreview.swift
+++ b/Sources/StorybookKit/Primitives/BookPreview.swift
@@ -46,14 +46,14 @@ public struct BookPreview: BookView {
 
   public let declarationIdentifier: DeclarationIdentifier
 
-  private let file: StaticString
-  private let line: UInt
+  private let file: String
+  private let line: Int
   private let title: String?
   private var frameConstraint: FrameConstraint = .init()
 
   public init(
-    _ file: StaticString = #fileID,
-    _ line: UInt = #line,
+    _ file: String = #fileID,
+    _ line: Int = #line,
     title: String? = nil,
     viewBlock: @escaping @MainActor (inout Context) -> UIView
   ) {

--- a/Sources/StorybookKit/Primitives/BookStore.swift
+++ b/Sources/StorybookKit/Primitives/BookStore.swift
@@ -44,13 +44,13 @@ public final class BookStore: ObservableObject {
 
   }
 
-  func onOpen(page: BookPage) {
+  func onOpen(pageID: DeclarationIdentifier) {
 
-    guard allPages.keys.contains(page.id) else {
+    guard allPages.keys.contains(pageID) else {
       return
     }
 
-    let index = page.declarationIdentifier.index
+    let index = pageID.index
 
     var current = userDefaults.array(forKey: "history") as? [Int] ?? []
     if let index = current.firstIndex(of: index) {

--- a/Sources/StorybookKitTextureSupport/BookNodePreview.swift
+++ b/Sources/StorybookKitTextureSupport/BookNodePreview.swift
@@ -30,13 +30,13 @@ public struct BookNodePreview: BookView {
   private var backing: BookPreview
 
   public init(
-    _ file: String = #fileID,
-    _ line: Int = #line,
+    _ fileID: any StringProtocol = #fileID,
+    _ line: any FixedWidthInteger = #line,
     title: String? = nil,
     nodeBlock: @escaping @MainActor (inout BookPreview.Context) -> ASDisplayNode
   ) {
     
-    self.backing = .init(file, line, title: title) { context in
+    self.backing = .init(fileID, line, title: title) { context in
       let body = nodeBlock(&context)
 
       let node = AnyDisplayNode { _, size in

--- a/Sources/StorybookKitTextureSupport/BookNodePreview.swift
+++ b/Sources/StorybookKitTextureSupport/BookNodePreview.swift
@@ -30,8 +30,8 @@ public struct BookNodePreview: BookView {
   private var backing: BookPreview
 
   public init(
-    _ file: StaticString = #fileID,
-    _ line: UInt = #line,
+    _ file: String = #fileID,
+    _ line: Int = #line,
     title: String? = nil,
     nodeBlock: @escaping @MainActor (inout BookPreview.Context) -> ASDisplayNode
   ) {


### PR DESCRIPTION
TODO:
- Using `UIView` or `UIViewController` in iOS 17 `#Preview` is currently not supported because the view factory used by SwiftUI is exposed as `@MainActor () -> UIView` , but since we now use Swift 6 compiler, it cannot be casted directly to `@MainActor @Sendable () -> UIView` (`@MainActor` now implies `@Sendable`)

https://forums.swift.org/t/is-there-any-real-difference-between-mainactor-sendable-and-mainactor/72525/8
https://github.com/swiftlang/swift-evolution/blob/main/proposals/0434-global-actor-isolated-types-usability.md

- ~We still need a way to filter out unwanted `#Preview`s (ex: Previews inside the StoryBookKit are also being extracted). I'm currently looking at `Preview.ViewTraits` if this is customizable for our own use~ Since the list is now grouped by modules, this is not an issue anymore