### PR TITLE
[codex] Add Storybook deeplink visual check workflow

### DIFF
--- a/.agents/skills/swift-storybook-visual-check/SKILL.md
+++ b/.agents/skills/swift-storybook-visual-check/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: swift-storybook-visual-check
+description: Use when validating iOS UI work through swift-storybook by opening Storybook deep links in a simulator, inferring page IDs from #Preview declarations when needed, and capturing screenshots to confirm the rendered result.
+---
+
+# Swift Storybook Visual Check
+
+Use this skill to verify UI changes in an iOS app that embeds `swift-storybook`. The goal is to open the exact Storybook page for the UI being changed, capture the simulator screen, and compare the result with the implementation intent.
+
+## Workflow
+
+1. Identify the app target, scheme, simulator, and Storybook URL scheme.
+2. Build and run the iOS app. Prefer the repo's requested Xcode MCP tooling when available.
+3. Find the Storybook page URL.
+4. Open the URL in the simulator.
+5. Capture a screenshot and verify that the expected page, title, and rendered UI are visible.
+
+## Finding The Page URL
+
+Prefer sources in this order:
+
+1. Use a Storybook manifest if the app exposes one.
+2. Use a copied deep link from the Storybook page if available.
+3. Infer the page ID from source code.
+4. If inference fails, open the Storybook root and use search.
+
+For current `#Preview` pages, the page ID is usually:
+
+```text
+<module-name>/<file-name>.swift:<preview-declaration-line>
+```
+
+Example:
+
+```swift
+#Preview("Circle") {
+  Circle()
+}
+```
+
+If that declaration starts at line 24 in `SwiftUIDemoApp/Component.swift`, infer:
+
+```text
+SwiftUIDemoApp/Component.swift:24
+```
+
+Then open:
+
+```text
+storybook://page?id=SwiftUIDemoApp/Component.swift:24
+```
+
+Important details:
+
+- The preview display name is not the page ID.
+- The ID is based on runtime `PreviewRegistry.fileID` and `PreviewRegistry.line`.
+- The line is the line where the `#Preview` declaration starts.
+- `fileID` is usually `<ModuleName>/<FileName.swift>`, not an absolute file path.
+- Re-check line numbers after editing, formatting, or inserting previews.
+- Multiple previews with the same display name are distinguished by `fileID:line`.
+- URL encoding of `/` and `:` in the query value is acceptable.
+
+## Opening A Deep Link
+
+Use the booted simulator id when known:
+
+```bash
+xcrun simctl openurl <simulator-id> 'storybook://page?id=SwiftUIDemoApp/Component.swift:24'
+```
+
+If the app is already installed, this can launch the app from a stopped state. iOS may show a one-time "Open in <App>?" confirmation; accept it before judging the result.
+
+## SwiftUI Host Apps
+
+SwiftUI host apps can rely on Storybook's SwiftUI entry point when the Storybook view is already in the app tree. For app-wide deep links, route URLs from the app root and present Storybook before passing the URL into Storybook.
+
+## UIKit Host Apps
+
+Do not rely on SwiftUI `.onOpenURL` in UIKit apps. Find the URL entry point in `SceneDelegate` or `AppDelegate`, present the Storybook view controller if it is not visible, then pass the URL to Storybook.
+
+Expected host flow:
+
+```text
+SceneDelegate/AppDelegate URL callback
+  -> present Storybook
+  -> pass deep link URL
+  -> Storybook resolves page ID
+  -> Storybook opens the page
+```
+
+## Verification
+
+After opening the URL, capture a screenshot with the available simulator tooling. Confirm:
+
+- The navigation title matches the target preview title.
+- The rendered UI matches the component you changed.
+- The page is not merely the Storybook root or search screen.
+
+If the page does not open:
+
+- Confirm the app has registered the URL scheme in `Info.plist`.
+- Confirm the app was rebuilt after adding or moving the preview.
+- Recompute the ID from the current `#Preview` line.
+- Try opening the Storybook root and searching for the preview title.
+- If available, prefer the manifest over source inference.

--- a/.agents/skills/swift-storybook-visual-check/agents/openai.yaml
+++ b/.agents/skills/swift-storybook-visual-check/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Swift Storybook Visual Check
+short_description: Open swift-storybook deep links in a simulator and verify UI screenshots.
+default_prompt: Validate this iOS UI change through swift-storybook by opening the relevant Storybook page in the simulator and capturing a screenshot.

--- a/Development/Storybook.xcodeproj/project.pbxproj
+++ b/Development/Storybook.xcodeproj/project.pbxproj
@@ -63,9 +63,19 @@
 		4BA377D62D4CE2F000D4E565 /* DynamicFrameworkComponents.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = DynamicFrameworkComponents.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		4BA378012D4D7B2B00D4E565 /* Exceptions for "SwiftUIDemoApp" folder in "SwiftUIDemoApp" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 4BA377A62D4CE2C500D4E565 /* SwiftUIDemoApp */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		4B8438CD2D4CE44C00BE1DA9 /* StaticLibraryComponents */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = StaticLibraryComponents; sourceTree = "<group>"; };
-		4BA377A82D4CE2C500D4E565 /* SwiftUIDemoApp */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = SwiftUIDemoApp; sourceTree = "<group>"; };
+		4BA377A82D4CE2C500D4E565 /* SwiftUIDemoApp */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (4BA378012D4D7B2B00D4E565 /* Exceptions for "SwiftUIDemoApp" folder in "SwiftUIDemoApp" target */, ); explicitFileTypes = {}; explicitFolders = (); path = SwiftUIDemoApp; sourceTree = "<group>"; };
 		4BA377D72D4CE2F000D4E565 /* DynamicFrameworkComponents */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = DynamicFrameworkComponents; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
@@ -368,7 +378,8 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = SwiftUIDemoApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -405,7 +416,8 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = SwiftUIDemoApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Development/SwiftUIDemoApp/Info.plist
+++ b/Development/SwiftUIDemoApp/Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>jp.eure.SwiftUIDemoApp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>storybook</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict>
+		<key>UILaunchScreen</key>
+		<dict/>
+	</dict>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "Storybook",
   platforms: [
-    .iOS(.v16),
+    .iOS(.v17),
     .macCatalyst(.v15),
     .macOS(.v10_15),
   ],

--- a/README.md
+++ b/README.md
@@ -58,8 +58,102 @@ In a static library module
 
 <img width="150px" src="https://github.com/user-attachments/assets/f849a5a1-c0df-4551-a9a8-c5a0367fe459" alt="list of modules">
 
+## Deep links
+
+Storybook can open a page from a URL once the host app registers a URL scheme.
+This is useful for automated UI validation because an agent can build the app,
+open a Storybook page directly in Simulator, and capture a screenshot of the
+rendered component.
+
+### Configure the host app
+
+Register a URL scheme in the host app's `Info.plist`.
+
+```xml
+<key>CFBundleURLTypes</key>
+<array>
+  <dict>
+    <key>CFBundleURLName</key>
+    <string>com.example.MyApp</string>
+    <key>CFBundleURLSchemes</key>
+    <array>
+      <string>my-storybook</string>
+    </array>
+  </dict>
+</array>
+```
+
+Pass the same scheme to Storybook:
+
+```swift
+Storybook(deepLinkScheme: "my-storybook")
+```
+
+The URL format is:
+
+```text
+my-storybook://page?id=<page-stable-id>
+```
+
+Each page screen has a link button that copies its deep link to the pasteboard.
+
+### Page IDs
+
+For pages created from `#Preview`, Storybook uses the preview source location as
+the stable page ID:
+
+```text
+<module-name>/<file-name>.swift:<preview-declaration-line>
+```
+
+For example, this preview:
+
+```swift
+#Preview("Circle") {
+  Circle()
+}
+```
+
+declared at line 24 in `SwiftUIDemoApp/Component.swift` can be opened with:
+
+```text
+my-storybook://page?id=SwiftUIDemoApp/Component.swift:24
+```
+
+The preview display name is not the ID. Multiple previews can share the same
+display name because they are distinguished by `fileID:line`. Re-check the line
+number after editing or formatting previews.
+
+### Opening a page in Simulator
+
+After installing the host app on a simulator, open the page with `simctl`:
+
+```bash
+xcrun simctl openurl booted 'my-storybook://page?id=SwiftUIDemoApp/Component.swift:24'
+```
+
+iOS may show a one-time confirmation dialog before opening the app from a custom
+scheme. Accept it, then repeat the command if necessary.
+
+### UIKit host apps
+
+SwiftUI apps can receive URLs through `.onOpenURL` when Storybook is already in
+the view tree. UIKit apps should route URLs from `SceneDelegate` or
+`AppDelegate`, present the Storybook UI if needed, then pass the URL into
+Storybook so it can resolve and open the page.
+
+### Agent workflow
+
+This repository includes a Codex skill at
+`.agents/skills/swift-storybook-visual-check`. It documents the recommended
+agent flow:
+
+1. Prefer a Storybook manifest if the host app exposes one.
+2. Otherwise infer the page ID from the `#Preview` declaration location.
+3. Build and run the app in Simulator.
+4. Open the Storybook deep link.
+5. Capture a screenshot and verify that the target page rendered.
+
 ## License
 
 Storybook-ios is released under the MIT license.
-
-

--- a/Sources/StorybookKit/Primitives/Book.swift
+++ b/Sources/StorybookKit/Primitives/Book.swift
@@ -6,8 +6,8 @@ public struct Book: BookView, Identifiable, Sendable {
 
     public var id: String {
       switch self {
-      case .folder(let v): return "folder.\(v.id)"
-      case .page(let v): return "page.\(v.id)"
+      case .folder(let v): return "folder.\(v.id.stableID)"
+      case .page(let v): return "page.\(v.id.stableID)"
       }
     }
 
@@ -31,18 +31,29 @@ public struct Book: BookView, Identifiable, Sendable {
 
   }
 
-  public var id: UUID = .init()
+  public nonisolated let declarationIdentifier: DeclarationIdentifier
+  private let fileID: any StringProtocol
+  private let line: any FixedWidthInteger
+
+  public nonisolated var id: DeclarationIdentifier {
+    declarationIdentifier
+  }
 
   public let title: String
   public let contents: [Node]
-  
+
   @State private var isExpandedAll: Bool = false
 
   public init(
+    _ fileID: any StringProtocol = #fileID,
+    _ line: any FixedWidthInteger = #line,
     title: String,
     @FolderBuilder contents: () -> [Node]
   ) {
 
+    self.fileID = fileID
+    self.line = line
+    self.declarationIdentifier = .init(fileID: String(fileID), line: Int(line))
     self.title = title
 
     let _contents = contents()
@@ -79,8 +90,10 @@ public struct Book: BookView, Identifiable, Sendable {
 
   }
 
+  @Environment(\.bookContext) var bookContext
+
   public var body: some View {
-    Section { 
+    Section {
       ForEach(contents) { node in
         NodeOutlineGroup(expandsAll: isExpandedAll, node, children: \.children) { content in
           switch content {
@@ -90,13 +103,23 @@ public struct Book: BookView, Identifiable, Sendable {
               Image.init(systemName: "folder.fill")
                 .foregroundStyle(.blue)
               Text(folder.title)
+              Spacer()
+              if let store = bookContext {
+                Button {
+                  store.togglePin(node: .folder(folder))
+                } label: {
+                  Image(systemName: store.isPinned(node: .folder(folder)) ? "pin.fill" : "pin")
+                    .foregroundStyle(.orange)
+                }
+                .buttonStyle(.plain)
+              }
             }
 
           case .page(let page):
             page
           }
         }
-        
+
       }
     } header: {
       HStack {
@@ -108,7 +131,7 @@ public struct Book: BookView, Identifiable, Sendable {
         .font(.caption)
       }
     }
-   
+
   }
 
   func allPages() -> [BookPage] {
@@ -152,6 +175,8 @@ extension Book {
     return fileIDsByModule.keys.sorted().map { module in
       return Node.folder(
         .init(
+          module, // Use module name as fileID
+          0,      // Use 0 as line for module-level folders
           title: module,
           contents: { [fileIDs = fileIDsByModule[module]!.sorted()] in
             fileIDs.map { fileID in
@@ -161,6 +186,8 @@ extension Book {
 
               return Node.folder(
                 .init(
+                  fileID,           // Use actual fileID
+                  registries[0].line, // Use first registry's line
                   title: name,
                   contents: {
                     registries.map { registry in

--- a/Sources/StorybookKit/Primitives/BookPage.swift
+++ b/Sources/StorybookKit/Primitives/BookPage.swift
@@ -22,17 +22,82 @@
 import Foundation
 import SwiftUI
 import ResultBuilderKit
+#if canImport(UIKit)
+import UIKit
+#endif
 
 public struct DeclarationIdentifier: Hashable, Codable, Sendable {
 
-  public let index: Int
+  enum Storage: Hashable, Codable {
+    case index(Int)
+    case location(fileID: String, line: Int)
+  }
+
+  let storage: Storage
 
   nonisolated init() {
-    index = issueUniqueNumber()
+    self.storage = .index(issueUniqueNumber())
+  }
+
+  public init(fileID: String, line: Int) {
+    self.storage = .location(fileID: fileID, line: line)
   }
 
   public init(raw index: Int) {
-    self.index = index
+    self.storage = .index(index)
+  }
+
+  public init?(stableID: String) {
+    if stableID.hasPrefix("index:") {
+      let value = stableID.dropFirst("index:".count)
+      guard let index = Int(value) else {
+        return nil
+      }
+      self.storage = .index(index)
+      return
+    }
+
+    guard
+      let separator = stableID.lastIndex(of: ":"),
+      separator > stableID.startIndex,
+      let line = Int(stableID[stableID.index(after: separator)...])
+    else {
+      return nil
+    }
+
+    self.storage = .location(
+      fileID: String(stableID[..<separator]),
+      line: line
+    )
+  }
+
+  // For backward compatibility with History feature
+  var index: Int {
+    switch storage {
+    case .index(let i):
+      return i
+    case .location(let fileID, let line):
+      return Self.stableHash("\(fileID):\(line)")
+    }
+  }
+
+  // Stable string representation for identification
+  public var stableID: String {
+    switch storage {
+    case .index(let i):
+      return "index:\(i)"
+    case .location(let fileID, let line):
+      return "\(fileID):\(line)"
+    }
+  }
+
+  private static func stableHash(_ value: String) -> Int {
+    var hash: UInt64 = 14_695_981_039_346_656_037
+    for byte in value.utf8 {
+      hash ^= UInt64(byte)
+      hash &*= 1_099_511_628_211
+    }
+    return Int(hash % UInt64(Int.max))
   }
 }
 
@@ -75,36 +140,52 @@ public struct BookPage: BookView, Identifiable, Sendable {
     self.title = title
     self.usesScrollView = usesScrollView
     self.destination = { AnyView(destination()) }
-    self.declarationIdentifier = .init()
+    self.declarationIdentifier = .init(fileID: String(fileID), line: Int(line))
   }
 
   public var body: some View {
 
     NavigationLink {
-      Group {
-        if usesScrollView {
-          ScrollView {
-            Display(content: destination)
-          }
-        } else {
-          Display(content: destination)
-        }
-      }
-      .listStyle(.plain)
-      .navigationTitle(title)
-      .navigationBarTitleDisplayMode(.inline)
-      .onAppear(perform: {
-        context?.onOpen(pageID: id)
-      })
+      BookPageDestination(page: self)
     } label: {
-      LinkLabel(title: title, fileID: fileID, line: line)
+      LinkLabel(page: self, title: title, fileID: fileID, line: line)
 //        .contextMenu(menuItems: {
 //          Text(title)
-//        }) { 
+//        }) {
 //          destination
 //        }
     }
    
+  }
+}
+
+struct BookPageDestination: View {
+
+  @Environment(\.bookContext) private var context
+
+  let page: BookPage
+
+  var body: some View {
+    Group {
+      if page.usesScrollView {
+        ScrollView {
+          Display(content: page.destination)
+        }
+      } else {
+        Display(content: page.destination)
+      }
+    }
+    .listStyle(.plain)
+    .navigationTitle(page.title)
+    .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .topBarTrailing) {
+        DeepLinkCopyButton(pageID: page.id)
+      }
+    }
+    .onAppear(perform: {
+      context?.onOpen(pageID: page.id)
+    })
   }
 }
 
@@ -131,7 +212,10 @@ private struct Display: View {
 }
 
 private struct LinkLabel: View {
-  
+
+  @Environment(\.bookContext) var bookContext
+
+  let page: BookPage
   let title: any StringProtocol
   let fileID: any StringProtocol
   let line: any FixedWidthInteger
@@ -146,6 +230,50 @@ private struct LinkLabel: View {
           .font(.caption.monospacedDigit())
           .opacity(0.8)
       }
+      Spacer()
+      if let store = bookContext {
+        Button {
+          store.togglePin(node: .page(page))
+        } label: {
+          Image(systemName: store.isPinned(node: .page(page)) ? "pin.fill" : "pin")
+            .foregroundStyle(.orange)
+        }
+        .buttonStyle(.plain)
+      }
     }
+    .contextMenu {
+      DeepLinkCopyButton(pageID: page.id, title: "Copy Deep Link")
+    }
+  }
+}
+
+private struct DeepLinkCopyButton: View {
+
+  @Environment(\.bookContext) private var bookContext
+
+  let pageID: DeclarationIdentifier
+  var title: String?
+
+  var body: some View {
+    if let url = bookContext?.deepLinkURL(for: pageID) {
+      Button {
+        StorybookClipboard.copy(url)
+      } label: {
+        if let title {
+          Label(title, systemImage: "link")
+        } else {
+          Image(systemName: "link")
+        }
+      }
+    }
+  }
+}
+
+private enum StorybookClipboard {
+
+  static func copy(_ url: URL) {
+    #if canImport(UIKit)
+    UIPasteboard.general.url = url
+    #endif
   }
 }

--- a/Sources/StorybookKit/Primitives/BookStore.swift
+++ b/Sources/StorybookKit/Primitives/BookStore.swift
@@ -1,35 +1,60 @@
 
-@MainActor
-public final class BookStore: ObservableObject {
+import Foundation
+import Observation
 
-  @Published var historyPages: [BookPage] = []
+@Observable
+@MainActor
+public final class BookStore {
+
+  var historyPages: [BookPage] = []
+  var pinnedNodes: [Book.Node] = []
 
   public let title: String
   public let book: Book
+  public let deepLinkScheme: String?
 
   private let allPages: [BookPage.ID: BookPage]
+  private let allPagesByStableID: [String: BookPage]
   private let folderPages: [String: (book: Book, pageIDs: Set<BookPage.ID>)]
+  private var allNodes: [String: Book.Node] = [:]
 
   private let userDefaults = UserDefaults(suiteName: "jp.eure.storybook2") ?? .standard
+  private enum DefaultsKey {
+    static let historyPageIDs = "historyPageIDs"
+    static let legacyHistoryIndexes = "history"
+    static let pinnedNodes = "pinnedNodes"
+  }
 
   public init(
-    book: Book
+    book: Book,
+    deepLinkScheme: String? = StorybookDeepLink.defaultScheme
   ) {
 
     self.title = book.title
     self.book = book
+    self.deepLinkScheme = deepLinkScheme
 
-    self.allPages = book.allPages().reduce(
+    let pages = book.allPages()
+
+    self.allPages = pages.reduce(
       into: [BookPage.ID: BookPage](),
       { partialResult, item in
         partialResult[item.id] = item
       }
     )
+    self.allPagesByStableID = pages.reduce(
+      into: [String: BookPage](),
+      { partialResult, item in
+        partialResult[item.id.stableID] = item
+      }
+    )
 
-    // Build folder-to-pages mapping for search
+    // Build folder-to-pages mapping for search and allNodes for pin management
     var folderPagesMap: [String: (book: Book, pageIDs: Set<BookPage.ID>)] = [:]
+    var allNodesMap: [String: Book.Node] = [:]
     func traverseNodes(_ nodes: [Book.Node], folderTitle: String? = nil) {
       for node in nodes {
+        allNodesMap[node.id] = node
         switch node {
         case .folder(let folder):
           let pages = folder.allPages()
@@ -43,13 +68,21 @@ public final class BookStore: ObservableObject {
     }
     traverseNodes(book.contents)
     self.folderPages = folderPagesMap
+    self.allNodes = allNodesMap
 
     updateHistory()
+    loadPinnedNodes()
   }
 
   private func updateHistory() {
 
-    let indexes = userDefaults.array(forKey: "history") as? [Int] ?? []
+    let pageIDs = userDefaults.stringArray(forKey: DefaultsKey.historyPageIDs) ?? []
+    if pageIDs.isEmpty == false {
+      historyPages = pageIDs.compactMap { allPagesByStableID[$0] }
+      return
+    }
+
+    let indexes = userDefaults.array(forKey: DefaultsKey.legacyHistoryIndexes) as? [Int] ?? []
 
     let _pages = indexes.compactMap { (index: Int) -> BookPage? in
       let id = DeclarationIdentifier(raw: index)
@@ -69,24 +102,51 @@ public final class BookStore: ObservableObject {
       return
     }
 
-    let index = pageID.index
+    let stableID = pageID.stableID
 
-    var current = userDefaults.array(forKey: "history") as? [Int] ?? []
-    if let index = current.firstIndex(of: index) {
+    var current = userDefaults.stringArray(forKey: DefaultsKey.historyPageIDs) ?? []
+    if let index = current.firstIndex(of: stableID) {
       current.remove(at: index)
     }
 
-    current.insert(index, at: 0)
+    current.insert(stableID, at: 0)
     current = Array(current.prefix(5))
 
-    userDefaults.set(current, forKey: "history")
+    userDefaults.set(current, forKey: DefaultsKey.historyPageIDs)
 
     print("Update history", current)
 
     updateHistory()
   }
 
-  nonisolated func search(query: String) async -> [Book.Node] {
+  public func deepLinkURL(for pageID: DeclarationIdentifier) -> URL? {
+    guard let deepLinkScheme else {
+      return nil
+    }
+    return StorybookDeepLink.makeURL(
+      scheme: deepLinkScheme,
+      pageID: pageID
+    )
+  }
+
+  func deepLinkURL(for page: BookPage) -> URL? {
+    deepLinkURL(for: page.id)
+  }
+
+  public func page(forDeepLink url: URL) -> BookPage? {
+    guard
+      let deepLinkScheme,
+      let pageID = StorybookDeepLink.pageID(
+        from: url,
+        matchingScheme: deepLinkScheme
+      )
+    else {
+      return nil
+    }
+    return allPagesByStableID[pageID]
+  }
+
+  func search(query: String) async -> [Book.Node] {
 
     // Search through folders and pages
     var results: [(score: Double, node: Book.Node)] = []
@@ -130,5 +190,41 @@ public final class BookStore: ObservableObject {
     return sortedNodes
   }
 
-}
+  // MARK: - Pin Management
 
+  func togglePin(node: Book.Node) {
+    if let index = pinnedNodes.firstIndex(where: { $0.id == node.id }) {
+      pinnedNodes.remove(at: index)
+    } else {
+      pinnedNodes.insert(node, at: 0)
+    }
+    savePinnedNodes()
+  }
+
+  func isPinned(node: Book.Node) -> Bool {
+    pinnedNodes.contains(where: { $0.id == node.id })
+  }
+
+  private func loadPinnedNodes() {
+    guard let items = userDefaults.array(forKey: DefaultsKey.pinnedNodes) as? [[String: String]] else {
+      return
+    }
+
+    let nodes = items.compactMap { item -> Book.Node? in
+      guard let nodeIDString = item["id"] else {
+        return nil
+      }
+      return allNodes[nodeIDString]
+    }
+
+    pinnedNodes = nodes
+  }
+
+  private func savePinnedNodes() {
+    let items = pinnedNodes.map { node -> [String: String] in
+      return ["id": node.id]
+    }
+    userDefaults.set(items, forKey: DefaultsKey.pinnedNodes)
+  }
+
+}

--- a/Sources/StorybookKit/Storybook.swift
+++ b/Sources/StorybookKit/Storybook.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 @available(iOS 17.0, *)
 public struct Storybook: View  {
+
+  private let deepLinkScheme: String?
   
-  public init() {
-    
+  public init(deepLinkScheme: String? = StorybookDeepLink.defaultScheme) {
+    self.deepLinkScheme = deepLinkScheme
   }
   
   public var body: some View {
@@ -18,7 +20,8 @@ public struct Storybook: View  {
             }
           }
           
-        }
+        },
+        deepLinkScheme: deepLinkScheme
       )
     )
   }

--- a/Sources/StorybookKit/StorybookDeepLink.swift
+++ b/Sources/StorybookKit/StorybookDeepLink.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+public enum StorybookDeepLink {
+
+  public static let defaultScheme = "storybook"
+
+  public static func makeURL(
+    scheme: String = Self.defaultScheme,
+    pageID: DeclarationIdentifier
+  ) -> URL? {
+    makeURL(scheme: scheme, pageID: pageID.stableID)
+  }
+
+  public static func makeURL(
+    scheme: String = Self.defaultScheme,
+    pageID: String
+  ) -> URL? {
+    guard pageID.isEmpty == false else {
+      return nil
+    }
+
+    var components = URLComponents()
+    components.scheme = scheme
+    components.host = "page"
+    components.queryItems = [
+      .init(name: "id", value: pageID)
+    ]
+    return components.url
+  }
+
+  public static func pageID(
+    from url: URL,
+    matchingScheme scheme: String? = nil
+  ) -> String? {
+    if let scheme {
+      guard url.scheme?.caseInsensitiveCompare(scheme) == .orderedSame else {
+        return nil
+      }
+    }
+
+    guard url.host == "page" || url.path == "/page" else {
+      return nil
+    }
+
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    return components?
+      .queryItems?
+      .first(where: { $0.name == "id" })?
+      .value
+  }
+}

--- a/Sources/StorybookKit/StorybookDisplayRootView.swift
+++ b/Sources/StorybookKit/StorybookDisplayRootView.swift
@@ -65,7 +65,7 @@ struct BookContainer: View {
 
   // MARK: Properties
 
-  @ObservedObject private var store: BookStore
+  private var store: BookStore
 
   @AppStorage("autoOpenLastPage", store: BookContainer.userDefaults)
   private var autoOpenLastPage: Bool = true
@@ -120,7 +120,34 @@ struct BookContainer: View {
             Text("Search Result")
           }
         }
-      
+
+        if store.pinnedNodes.isEmpty == false {
+          Section {
+            ForEach(store.pinnedNodes) { node in
+              Group {
+                switch node {
+                case .folder(let folder):
+                  DisclosureGroup {
+                    ForEach(folder.contents) { childNode in
+                      SearchResultNodeView(node: childNode)
+                    }
+                  } label: {
+                    HStack {
+                      Image(systemName: "folder.fill")
+                        .foregroundStyle(.blue)
+                      Text(folder.title)
+                    }
+                  }
+                case .page(let page):
+                  page
+                }
+              }
+            }
+          } header: {
+            Text("Pinned")
+          }
+        }
+
         Section {
           ForEach(store.historyPages) { link in
             link
@@ -144,9 +171,7 @@ struct BookContainer: View {
         }
       }
       .navigationDestination(for: UniqueBox<BookPage>.self) { page in
-        page
-          .value
-          .destination()
+        BookPageDestination(page: page.value)
           .environment(\.bookContext, store)
       }
       .sheet(isPresented: $showSettings) {
@@ -162,11 +187,17 @@ struct BookContainer: View {
       }
       // Use Task to hop as somehow iOS26 gets hangs when back to top by using back button.
       Task {
+        guard path.isEmpty else {
+          return
+        }
         if let value = store.historyPages.first {
           print("📱 Auto-opening last page: \(value.title)")
-          path.append(UniqueBox(value: value))
+          open(page: value)
         }
       }
+    }
+    .onOpenURL { url in
+      openDeepLink(url)
     }
     .onChange(of: query, perform: { value in
       
@@ -189,6 +220,21 @@ struct BookContainer: View {
       }
       
     })    
+  }
+
+  private func openDeepLink(_ url: URL) {
+    guard let page = store.page(forDeepLink: url) else {
+      return
+    }
+    open(page: page)
+  }
+
+  private func open(page: BookPage) {
+    currentTask?.cancel()
+    query = ""
+    result = []
+    path = .init()
+    path.append(UniqueBox(value: page))
   }
 
 }


### PR DESCRIPTION
## Summary

This PR adds deep link support for opening specific Storybook pages from a host app URL scheme, then documents the workflow an agent can use to verify UI changes in Simulator.

## Changes

- Adds stable page IDs based on source location (`fileID:line`) while preserving legacy index-based history lookup.
- Adds `StorybookDeepLink` URL generation/parsing for `scheme://page?id=<page-stable-id>`.
- Wires Storybook page opening through URL handling and adds deep-link copy affordances on page screens.
- Registers the demo app's `storybook` URL scheme through a manual `Info.plist`.
- Expands README documentation with host app setup, page ID inference, Simulator opening, UIKit host app guidance, and the agent verification flow.
- Adds the `.agents/skills/swift-storybook-visual-check` Codex skill for opening Storybook pages and capturing screenshots during UI validation.

## Why

The intended workflow is for an AI agent to implement UI, launch the host app, open the relevant Storybook page directly, and capture a screenshot to verify the rendered result. The page ID can be discovered from a manifest in the future, copied from Storybook, or inferred from a `#Preview` declaration as `<Module>/<File>.swift:<line>`.

## Validation

- `git diff --cached --check`
- Built and launched `SwiftUIDemoApp` with XcodeBuildMCP on iPhone 17 Pro simulator, iOS 26.5.
- Verified `storybook://page?id=SwiftUIDemoApp/Component.swift:24` opens the `Circle` page.
- During development, also verified a newly added `#Preview` could be targeted by its inferred `fileID:line` ID, then removed that temporary preview from the final diff.