### PR TITLE
Improve Storybook documentation and agentic workflow

### DIFF
--- a/.agents/skills/create-storybook-project-skill/SKILL.md
+++ b/.agents/skills/create-storybook-project-skill/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: create-storybook-project-skill
+description: "Configure an iOS host project for deterministic StorybookKit startup and create a project-local visual-check skill with its exact build, install, launch, selector, and verification workflow. Use when onboarding StorybookKit for agentic coding, exposing project-specific environment variables that launch the catalog or one #Preview, or replacing a generic Storybook workflow with a repository-specific skill."
+---
+
+# Create a Storybook Project Skill
+
+Configure the target app to open Storybook through its real startup path, then generate a self-contained Skill that can repeat the project's exact visual-check workflow.
+
+## Preserve the contract boundary
+
+Keep these responsibilities separate:
+
+- Let StorybookKit own the project-independent `--storybook` launch arguments.
+- Let the host app parse `StorybookLaunchRequest` before constructing its normal root UI.
+- Let the project's runner translate project-specific environment variables into the standard arguments.
+- Let the generated Skill own concrete repository facts such as the scheme, bundle identifier, configuration, simulator selection, and commands.
+
+Do not add project-specific environment-variable parsing to StorybookKit. Environment variables are a launcher interface; process arguments are the app-facing contract.
+
+Read [references/integration-contract.md](references/integration-contract.md) before changing the host app or its runner.
+
+## 1. Inspect the target project
+
+Read the target repository's instruction files completely before editing. Then locate and verify:
+
+1. The dependency declaration and configurations that link `StorybookKit`.
+2. The application startup boundary: SwiftUI `App`, scene delegate, app delegate, or a custom root coordinator.
+3. The existing Storybook catalog, `BookStore`, manual developer-menu entry, and preview discovery path.
+4. The canonical build/install/launch command and its simulator-selection behavior.
+5. The scheme, configuration, bundle identifier, supported app variants, and required generated workspace.
+6. One real `#Preview` that can serve as an exact launch probe.
+7. Existing repository-local Skills and their naming and tool conventions.
+
+Treat discovered values as evidence. Do not guess a scheme, bundle identifier, target, environment prefix, or app lifecycle from common iOS defaults.
+
+## 2. Connect programmable startup
+
+Reuse an existing host adapter when present. Otherwise implement the narrowest adapter that:
+
+1. Calls `StorybookLaunchRequest(arguments: ProcessInfo.processInfo.arguments)` at the earliest root-selection boundary.
+2. Keeps normal startup unchanged when the initializer returns `nil`.
+3. Replaces the normal root with `Storybook` or `StorybookDisplayRootView` when a request exists.
+4. Passes `.invalid` requests into Storybook so the diagnostic remains visible instead of silently falling back.
+5. Builds the catalog from the project's existing pages and `Book.allBookPreviews()`.
+6. Compiles only in the configurations where StorybookKit is linked.
+7. Preserves an existing manual in-app Storybook entry independently of programmable startup.
+
+Add host-specific options, such as a light/dark override, outside `StorybookLaunchRequest`. Parse them deterministically and convert invalid values into a visible `StorybookLaunchDiagnostic`.
+
+## 3. Expose a project launcher interface
+
+Prefer the project's existing simulator runner. Extend it with a stable uppercase prefix derived from the project, for example:
+
+```text
+<PREFIX>_STORYBOOK=1
+<PREFIX>_STORYBOOK_PAGE_NAME=<exact preview name>
+<PREFIX>_STORYBOOK_FILE_ID=<module/path/file.swift>
+<PREFIX>_STORYBOOK_PAGE_LINE=<positive declaration line>
+```
+
+Add host-specific variables only when the project needs them. Preserve an explicitly set empty page name, validate dependent qualifiers, and append each launch argument as a separate array element. Never assemble shell-evaluated argument strings.
+
+Support the repository's normal build-and-install path. When its tooling already supports relaunching an installed app without rebuilding, document that fast path in the generated Skill; otherwise state the actual build/install cost rather than inventing one.
+
+## 4. Generate the project-local Skill
+
+Create the Skill under the target repository's established skill root. Default to:
+
+```text
+.agents/skills/<project-slug>-storybook-visual-check
+```
+
+Copy [assets/project-skill-template](assets/project-skill-template) as the starting point. Replace every template placeholder, delete inapplicable optional sections, and keep the result project-specific.
+
+Record concrete values for:
+
+- repository root and prerequisite generation/setup;
+- supported target, scheme, configuration, and bundle identifier;
+- canonical runner command and environment variables;
+- installed-app relaunch path, only when verified;
+- exact page-name, file-ID, and line-selection behavior;
+- appearance or locale controls owned by the host;
+- hierarchy identifier and screenshot tool;
+- cleanup requirements for device-interaction sessions;
+- known unsupported variants and honest failure conditions.
+
+Do not make the generated Skill another generic Storybook guide. It should remove repository discovery work from every future visual check.
+
+## 5. Validate the integration and Skill
+
+Validate in proportion to the changes:
+
+1. Run the target repository's preferred incremental build for the host configuration.
+2. Launch the catalog through the environment-variable interface.
+3. Launch one exact preview by name, adding file ID and line if necessary.
+4. Verify the exact `storybook.page|...` accessibility identifier before capturing a screenshot.
+5. Confirm that launching without Storybook inputs still follows normal startup.
+6. Validate the generated Skill with the available Skill validator.
+7. Search for unresolved template placeholders and conflict markers.
+
+If build, install, launch, exact selection, hierarchy verification, or screenshot capture cannot be completed, report the failed stage. Do not substitute a catalog launch, another page, or a build-only result for visual verification.
+
+## 6. Report the result
+
+Return:
+
+- host integration files changed;
+- environment-variable interface and exact example command;
+- generated Skill path;
+- supported and unsupported configurations;
+- build and launch validation performed;
+- screenshot artifact path when verification succeeded;
+- any prerequisite the project still needs.

--- a/.agents/skills/create-storybook-project-skill/agents/openai.yaml
+++ b/.agents/skills/create-storybook-project-skill/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Storybook Project Skill"
+  short_description: "Configure Storybook launch and a project visual-check skill"
+  default_prompt: "Use $create-storybook-project-skill to configure this iOS app for programmable Storybook launch and generate its project-specific visual-check skill."

--- a/.agents/skills/create-storybook-project-skill/assets/project-skill-template/SKILL.md
+++ b/.agents/skills/create-storybook-project-skill/assets/project-skill-template/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: {{SKILL_NAME}}
+description: "Launch and visually verify an exact StorybookKit page in {{PROJECT_NAME}} using the repository's supported build, install, and simulator workflow. Use after UI changes, when checking a #Preview or BookPage, or when source qualifiers are needed to select a duplicate page name."
+---
+
+# {{PROJECT_NAME}} Storybook Visual Check
+
+Use the host app's programmable Storybook startup to open one exact page and capture trustworthy Simulator evidence.
+
+## Project contract
+
+- Repository: `{{REPOSITORY_ROOT}}`
+- Workspace or project: `{{WORKSPACE_OR_PROJECT}}`
+- Scheme: `{{SCHEME}}`
+- Configuration: `{{CONFIGURATION}}`
+- Bundle identifier: `{{BUNDLE_IDENTIFIER}}`
+- Supported variants: {{SUPPORTED_VARIANTS}}
+- Setup prerequisite: `{{SETUP_COMMAND}}`
+- Canonical runner: `{{RUNNER_COMMAND}}`
+
+Do not substitute another target, configuration, bundle identifier, or generic build command.
+
+## Select the page
+
+Find the requested `#Preview` or `BookPage` in source. Start with its exact display name. Add the compiler `#fileID`, then the declaration line when the name is duplicated.
+
+Use these launcher variables:
+
+```text
+{{ENV_PREFIX}}_STORYBOOK=1
+{{ENV_PREFIX}}_STORYBOOK_PAGE_NAME=<exact page name>
+{{ENV_PREFIX}}_STORYBOOK_FILE_ID=<module/path/file.swift>
+{{ENV_PREFIX}}_STORYBOOK_PAGE_LINE=<positive declaration line>
+{{OPTIONAL_HOST_VARIABLES}}
+```
+
+Do not trim, normalize, fuzzy-match, or guess values. Preserve an explicitly empty page name.
+
+## Build, install, and launch
+
+Open the catalog:
+
+```bash
+env {{ENV_PREFIX}}_STORYBOOK=1 {{RUNNER_COMMAND}}
+```
+
+Open an exact page:
+
+```bash
+env \
+  {{ENV_PREFIX}}_STORYBOOK_PAGE_NAME='{{EXAMPLE_PAGE_NAME}}' \
+  {{ENV_PREFIX}}_STORYBOOK_FILE_ID='{{EXAMPLE_FILE_ID}}' \
+  {{ENV_PREFIX}}_STORYBOOK_PAGE_LINE='{{EXAMPLE_LINE}}' \
+  {{RUNNER_COMMAND}}
+```
+
+{{INSTALLED_APP_FAST_PATH}}
+
+Use the repository's supported simulator selection. Preserve inherited launch arguments required by its scheme or runner.
+
+## Verify before capture
+
+1. Wait for the UI to settle.
+2. Inspect the hierarchy for `storybook.page|<name-byte-count>:<name>|<fileID-byte-count>:<fileID>|<line>`.
+3. Confirm the requested content is visible.
+4. Reject `storybook.launch.failure`, normal app startup, catalog fallback, or another same-name page.
+5. Check clipping, overlap, missing content, unexpected loading, and incorrect presentation.
+6. Capture a screenshot only after exact hierarchy verification succeeds.
+7. End any device-interaction session after capture or failure.
+
+Save evidence under `{{ARTIFACT_DIRECTORY}}` and report the selector and screenshot path.
+
+## Fail honestly
+
+Stop at the failed stage when setup, build, install, launch, exact selection, hierarchy verification, or capture fails. Report the concrete diagnostic and do not substitute a build-only result or another page.
+
+Known constraints:
+
+{{KNOWN_CONSTRAINTS}}

--- a/.agents/skills/create-storybook-project-skill/assets/project-skill-template/agents/openai.yaml
+++ b/.agents/skills/create-storybook-project-skill/assets/project-skill-template/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "{{PROJECT_NAME}} Storybook Visual Check"
+  short_description: "Verify exact {{PROJECT_NAME}} Storybook pages on Simulator"
+  default_prompt: "Use ${{SKILL_NAME}} to open an exact Storybook page in {{PROJECT_NAME}}, verify it, and capture screenshot evidence."

--- a/.agents/skills/create-storybook-project-skill/references/integration-contract.md
+++ b/.agents/skills/create-storybook-project-skill/references/integration-contract.md
@@ -1,0 +1,165 @@
+# Storybook Host Integration Contract
+
+Use this reference while adapting an iOS host. Keep the standard StorybookKit contract stable and put repository-specific behavior at the host and launcher boundaries.
+
+## Standard launch arguments
+
+Pass arguments as distinct process arguments in this order:
+
+```text
+--storybook
+--storybook <page-name>
+--storybook --storybook-name=<page-name>
+--storybook <page-name> --storybook-file <module/path/file.swift>
+--storybook <page-name> --storybook-file <module/path/file.swift> --storybook-line <line>
+```
+
+Use the positional page name for ordinary non-empty names. Use the single argument `--storybook-name=<page-name>` when the name is empty or starts with `-`.
+
+The file identifier is the compiler-emitted `#fileID`, not an absolute path. The line is the positive source line of the preview declaration. Name-only selection must not pick the first duplicate; retry with file ID and then line.
+
+## SwiftUI lifecycle adapter
+
+Parse the request once, before choosing the normal root:
+
+```swift
+import StorybookKit
+import SwiftUI
+
+@main
+struct ExampleApp: App {
+  private let storybookLaunchRequest: StorybookLaunchRequest? = .init(
+    arguments: ProcessInfo.processInfo.arguments
+  )
+
+  var body: some Scene {
+    WindowGroup {
+      if let storybookLaunchRequest {
+        Storybook(launchRequest: storybookLaunchRequest)
+      } else {
+        AppRootView()
+      }
+    }
+  }
+}
+```
+
+Place conditional compilation around the import and branch when StorybookKit is not linked in every configuration.
+
+## UIKit lifecycle adapter
+
+Resolve the request before constructing the normal root view controller:
+
+```swift
+@MainActor
+private func makeRootViewController() -> UIViewController {
+#if canImport(StorybookKit)
+  if let request = StorybookLaunchRequest(
+    arguments: ProcessInfo.processInfo.arguments
+  ) {
+    return UIHostingController(
+      rootView: Storybook(launchRequest: request)
+    )
+  }
+#endif
+
+  return makeNormalRootViewController()
+}
+```
+
+Integrate this branch into the host's existing root factory instead of creating a second app lifecycle. If the project uses a custom `BookStore`, pass the request to `StorybookDisplayRootView(bookStore:launchRequest:)`.
+
+## Environment-variable launcher
+
+Use project-specific shell variables as a convenient input to the project's runner. Convert them into the standard argument array before invoking the app.
+
+```bash
+STORYBOOK_PAGE_NAME_IS_SET=0
+if [[ "${APP_STORYBOOK_PAGE_NAME+x}" == "x" ]]; then
+  STORYBOOK_PAGE_NAME_IS_SET=1
+fi
+
+if [[ -n "${APP_STORYBOOK_FILE_ID:-}" && "$STORYBOOK_PAGE_NAME_IS_SET" != "1" ]]; then
+  echo "APP_STORYBOOK_FILE_ID requires APP_STORYBOOK_PAGE_NAME." >&2
+  exit 1
+fi
+
+if [[ -n "${APP_STORYBOOK_PAGE_LINE:-}" && -z "${APP_STORYBOOK_FILE_ID:-}" ]]; then
+  echo "APP_STORYBOOK_PAGE_LINE requires APP_STORYBOOK_FILE_ID." >&2
+  exit 1
+fi
+
+if [[ "${APP_STORYBOOK:-0}" == "1" || "$STORYBOOK_PAGE_NAME_IS_SET" == "1" ]]; then
+  LAUNCH_ARGUMENTS+=("--storybook")
+
+  if [[ "$STORYBOOK_PAGE_NAME_IS_SET" == "1" ]]; then
+    if [[ -z "$APP_STORYBOOK_PAGE_NAME" || "$APP_STORYBOOK_PAGE_NAME" == -* ]]; then
+      LAUNCH_ARGUMENTS+=("--storybook-name=$APP_STORYBOOK_PAGE_NAME")
+    else
+      LAUNCH_ARGUMENTS+=("$APP_STORYBOOK_PAGE_NAME")
+    fi
+  fi
+
+  if [[ -n "${APP_STORYBOOK_FILE_ID:-}" ]]; then
+    LAUNCH_ARGUMENTS+=("--storybook-file" "$APP_STORYBOOK_FILE_ID")
+  fi
+
+  if [[ -n "${APP_STORYBOOK_PAGE_LINE:-}" ]]; then
+    LAUNCH_ARGUMENTS+=("--storybook-line" "$APP_STORYBOOK_PAGE_LINE")
+  fi
+fi
+```
+
+Replace `APP` with the project's stable prefix. Validate any restricted variant or configuration before building.
+
+Launch with array-preserving expansion:
+
+```bash
+xcrun simctl launch \
+  --terminate-running-process \
+  "$SIMULATOR_UDID" \
+  "$BUNDLE_ID" \
+  "${LAUNCH_ARGUMENTS[@]}"
+```
+
+Do not pass one quoted string containing several arguments. Do not use `eval`.
+
+`SIMCTL_CHILD_<NAME>` passes an environment variable into the app process. That is a separate mechanism and is not required by StorybookKit. Prefer translating the runner's project-specific variables into standard launch arguments unless the host has a real need for additional process environment.
+
+## Catalog construction
+
+For the default catalog, use `Storybook(launchRequest:)`. For a custom catalog, preserve existing pages and include discovered previews:
+
+```swift
+let store = BookStore(
+  book: Book(title: "Components") {
+    Book.allBookPreviews() ?? []
+  }
+)
+
+StorybookDisplayRootView(
+  bookStore: store,
+  launchRequest: request
+)
+```
+
+Keep manual in-app presentation separate from programmable startup. Manual presentation may retain last-page behavior; an explicit launch request must establish the requested page or show a diagnostic.
+
+## Deterministic verification
+
+After exact resolution succeeds, Storybook exposes this root identifier:
+
+```text
+storybook.page|<name-byte-count>:<name>|<fileID-byte-count>:<fileID>|<line>
+```
+
+Counts are UTF-8 byte counts. Verify the identifier and visible content before screenshot capture. Treat `storybook.launch.failure`, normal app startup, a catalog fallback, or another same-name page as failure.
+
+## Configuration safety
+
+- Link StorybookKit only in intended development or internal configurations unless the product explicitly ships it.
+- Guard code with the project's established compilation conditions.
+- Preserve normal startup when `--storybook` is absent.
+- Preserve unrelated host launch arguments.
+- Keep credentials, user data, and production-only services out of preview setup.
+- Do not claim physical-device automation when the verified workflow only supports Simulator.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,44 @@
 # Storybook for iOS
 
-This library allows you to view UI components in a catalog-style format.  
-In most cases, it works by simply adding a few lines of code, as it gathers SwiftUI preview codes at runtime.
+Turn the `#Preview` declarations already in your app into an in-app component catalog.
 
-<img width="150px" src="https://github.com/user-attachments/assets/c6819a8a-3685-422b-a561-16ab513ccd54" alt="storybook previewing">
+Add `Storybook()` once, then keep writing previews as usual. Storybook discovers them at runtime and adds them to the catalog automatically—there is no separate registration step.
 
-## Setup
+## Motivation
 
-1. Install this package into your project.
+Xcode previews can become difficult to keep working reliably in very large projects, especially when the build is complex. When that happens, existing `#Preview` declarations often stop contributing to the development loop even though they still describe valuable component states.
 
-2. Put the entrypoint view.
+Storybook was created to preserve that investment. It discovers previews from a regular app build and presents them as a catalog, allowing teams to reuse their preview code and maintain a smooth UI development loop through the build and runtime path their project already relies on.
+
+Even when Xcode previews work well, running Storybook as part of an app provides additional benefits:
+
+- Open previews directly on a physical device.
+- Keep the catalog available in the installed app across launches, independently of an Xcode preview session.
+- Include a Storybook entry point in debug or internal builds and open it from within the app whenever it is needed.
+
+## From `#Preview` to Storybook
+
+```swift
+#Preview("Circle") {
+  Circle()
+    .fill(.purple)
+    .frame(width: 100, height: 100)
+}
+```
+
+**The preview automatically appears in Storybook:**
+
+<img width="150px" src="https://github.com/user-attachments/assets/c6819a8a-3685-422b-a561-16ab513ccd54" alt="A SwiftUI preview automatically displayed in Storybook">
+
+The same declaration continues to work as an Xcode preview, so your preview code becomes the source of truth for both development and the in-app catalog.
+
+The included [`swift-storybook-visual-check`](.agents/skills/swift-storybook-visual-check/SKILL.md) skill also turns that catalog into a repeatable visual-check workflow for coding agents.
+
+## Quick start
+
+1. Add the package and link the `StorybookKit` product to your app.
+
+2. Put `Storybook` at the entry point of your catalog app or debug-only route.
 
 ```swift
 import StorybookKit
@@ -21,6 +50,42 @@ struct ContentView: View {
   }
 }
 ```
+
+3. Add `#Preview` declarations anywhere in the linked modules. No Storybook-specific registration is needed.
+
+```swift
+#Preview("Circle") {
+  Circle()
+    .fill(.purple)
+    .frame(width: 100, height: 100)
+}
+```
+
+## Preview discovery
+
+Storybook automatically discovers previews in the app executable and linked dynamic frameworks.
+
+> [!IMPORTANT]
+> Previews in a static library may require the `-all_load` linker flag. Without it, the linker can remove preview symbols that appear unused, preventing Storybook from discovering them.
+
+<img width="150px" src="https://github.com/user-attachments/assets/f849a5a1-c0df-4551-a9a8-c5a0367fe459" alt="list of modules">
+
+## Agentic Coding
+
+Storybook provides a deterministic bridge from UI code to visual verification in Simulator. The included [`swift-storybook-visual-check`](.agents/skills/swift-storybook-visual-check/SKILL.md) skill guides a coding agent through the complete check:
+
+1. Select an exact `#Preview` or `BookPage` by name.
+2. Disambiguate duplicate names with the source file and declaration line when needed.
+3. Launch the host app directly into that page.
+4. Verify its source-qualified accessibility identifier and rendered UI.
+5. Capture screenshot evidence only after the correct page is confirmed.
+
+This makes UI validation reproducible without navigating the catalog by hand or adding a separate route for every component.
+
+To onboard another app, use the [`create-storybook-project-skill`](.agents/skills/create-storybook-project-skill/SKILL.md) skill. It connects `StorybookLaunchRequest` to the host's real startup lifecycle, maps project-specific environment variables onto the standard launch arguments, and generates a repository-local visual-check skill with the exact scheme, bundle identifier, runner, and simulator workflow.
+
+> [!NOTE]
+> The host app must first connect `StorybookLaunchRequest` to its startup lifecycle and include `StorybookKit` in the selected build configuration. The package defines the launch contract but cannot replace an app's root UI on its own.
 
 ## Programmable launch
 
@@ -88,46 +153,6 @@ storybook.page|<name-byte-count>:<name>|<fileID-byte-count>:<fileID>|<line>
 ```
 
 The counts are UTF-8 byte counts. This lets automation prove that a qualified request opened the intended page before taking a screenshot.
-
-### Agent visual checks
-
-This repository includes the [`swift-storybook-visual-check`](.agents/skills/swift-storybook-visual-check/SKILL.md) skill. After the host adapter is connected, an Agent can use the same launch arguments to open the exact page, verify its hierarchy, and capture a simulator screenshot without navigating the catalog by hand.
-
-## Example
-
-In app executable module
-
-```swift
-#Preview("Circle") {
-  Circle()
-    .fill(.purple)
-    .frame(width: 100, height: 100)
-}
-```
-
-In a dynamic framework module
-```swift
-#Preview("Circle") {
-  Circle()
-    .fill(.purple)
-    .frame(width: 100, height: 100)
-}
-```
-
-In a static library module
-```swift
-#Preview("Circle") {
-  Circle()
-    .fill(.purple)
-    .frame(width: 100, height: 100)
-}
-```
-
-> [!IMPORTANT]
-> To display all preview codes in a statically linked binary, you may need to link the binary with the -all_load linker flag.
-> This is because the linker does not load symbols into the target binary if it deems them unnecessary.
-
-<img width="150px" src="https://github.com/user-attachments/assets/f849a5a1-c0df-4551-a9a8-c5a0367fe459" alt="list of modules">
 
 ## Maintainers
 


### PR DESCRIPTION
## Summary

- explain why Storybook is useful when Xcode previews become unreliable in large or complex projects
- highlight automatic `#Preview` discovery, device usage, installed catalog persistence, and embedded debug tooling
- document the Agentic Coding workflow and deterministic programmable launch contract
- add `create-storybook-project-skill` for integrating another host app and generating its repository-specific visual-check skill
- include reusable SwiftUI/UIKit integration guidance and a project-skill template

## Validation

- validated `create-storybook-project-skill` with the Skill validator
- syntax-checked the documented environment-variable launcher snippets with `bash -n`
- instantiated the project-skill template with `pairs-ios-full` values and validated the generated Skill
- ran `git diff --cached --check`

No Xcode build was run because this PR changes only documentation and Agent Skills.
